### PR TITLE
Pr/fix timezone gmt time

### DIFF
--- a/src/timezone.c
+++ b/src/timezone.c
@@ -60,7 +60,7 @@ time_t timezone_gmt_time(const char *timezone_name, const time_t local_time)
     {
         index++;
         result = local_time - (60 * tz->entries[index].offset);
-        if(result >= tz->entries[index].start)
+        if(result < tz->entries[index].end)
         {
             // Validate the result
             if(result < timezone_offset_max_time || result >= timezone_offset_min_time) return result;

--- a/test/timezone_gmt_time.c
+++ b/test/timezone_gmt_time.c
@@ -2,10 +2,9 @@
 #include "test.h"
 #include "timezone_database.h"
 
-static void test_gmtime(time_t gmtime, const char *timezonename)
+static void test_gmtime(const char *timezonename)
 {
-	const char timezonename[] = "America/Los_Angeles";
-	time_t basetime, gmtime, latime, revert, day_offset;
+	time_t basetime, gmtime, localtime, revert, day_offset;
 
 	// Get the gmt time
 	time(&basetime);
@@ -18,12 +17,19 @@ static void test_gmtime(time_t gmtime, const char *timezonename)
 		gmtime = basetime + day_offset;
 
 		// Get the time in LA
-		latime = timezone_local_time(timezonename, gmtime);
+		localtime = timezone_local_time(timezonename, gmtime);
+
+		// Verify the time was converted
+		TEST_TRUE(localtime > 0);
 
 		// Revert back to gmt
-		revert = timezone_gmt_time(timezonename, latime);
+		revert = timezone_gmt_time(timezonename, localtime);
 
 		// Verify the result
+		// TEST_EQUAL(gmtime, revert);
+		if(gmtime != revert) {
+			printf("Timezone %s failed\n", timezonename);
+		}
 		TEST_EQUAL(gmtime, revert);
 	}
 
@@ -31,9 +37,13 @@ static void test_gmtime(time_t gmtime, const char *timezonename)
 
 int main(void)
 {
-    const char timezonename[] = "America/Los_Angeles";
+	int i;
 
-    test_gmtime(25696800, timezonename);
+	// Loop through all timezones
+	for(i = 0; i < TIMEZONE_DATABASE_COUNT; i++) 
+	{
+		test_gmtime(timezone_array[i].name);
+	}
 
     return 0;
 }

--- a/test/timezone_gmt_time.c
+++ b/test/timezone_gmt_time.c
@@ -1,16 +1,10 @@
 #include "timezone.h"
 #include "test.h"
+#include "timezone_database.h"
 
-int main(void)
+static void test_gmtime(time_t gmtime, const char *timezonename)
 {
-	const char timezonename[] = "America/Los_Angeles";
-	time_t gmtime, latime, revert;
-
-	// Get the gmt time
-	time(&gmtime);
-
-	// Move the time a bit
-	gmtime += 86400 * 30;
+	time_t latime, revert;
 
 	// Get the time in LA
 	latime = timezone_local_time(timezonename, gmtime);
@@ -18,8 +12,20 @@ int main(void)
 	// Revert back to gmt
 	revert = timezone_gmt_time(timezonename, latime);
 
+	//printf("gmt: %ld", gmtime);
 	// Verify the result
+	if (gmtime != revert) {
+		printf("gmtime: %ld, latime: %ld, revert: %ld\n", gmtime, latime, revert);
+	}
 	TEST_EQUAL(gmtime, revert);
 
-	return 0;
+}
+
+int main(void)
+{
+    const char timezonename[] = "America/Los_Angeles";
+
+    test_gmtime(25696800, timezonename);
+
+    return 0;
 }


### PR DESCRIPTION
timezone_gmt_time always uses the first offset, since the check against start is wrong.