### PR TITLE
Pr/binary search timezone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ project (brutezone)
 
 include_directories ("${PROJECT_SOURCE_DIR}/inc")
 
-set(CMAKE_CONFIGURATION_TYPES "Release")
-
 add_library(${PROJECT_NAME}
     src/timezone.c
     src/timezone_impl.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,4 +11,5 @@ add_library(${PROJECT_NAME}
 
 # Support testing
 enable_testing()
+add_subdirectory(benchmark)
 add_subdirectory(test)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required (VERSION 2.6)
+
+include_directories(../inc)
+
+add_executable(find_timezone find_timezone.c)

--- a/benchmark/benchmark.h
+++ b/benchmark/benchmark.h
@@ -1,0 +1,16 @@
+#ifndef TIMEZONE_BENCHMARK_H
+#define TIMEZONE_BENCHMARK_H
+
+#include <time.h>
+
+static inline void escape(const void *p)
+{
+    asm volatile("" : : "g"(p) : "memory");
+}
+
+static inline unsigned long int timespec_diff_ns(const struct timespec *start, const struct timespec *end)
+{
+    return (end->tv_sec - start->tv_sec) * 1000000000 + end->tv_nsec - start->tv_nsec;
+}
+
+#endif

--- a/benchmark/find_timezone.c
+++ b/benchmark/find_timezone.c
@@ -1,0 +1,37 @@
+#include "benchmark.h"
+#include "timezone_database.h"
+#include <stdio.h>
+#include <time.h>
+
+#define ROUNDS 1000
+#define N_TIMEZONES sizeof(timezone_array) / sizeof(*timezone_array)
+
+int main(int argc, char **argv)
+{
+    struct timespec bm_start;
+    struct timespec bm_end;
+    int rc;
+
+    rc = clock_gettime(CLOCK_MONOTONIC, &bm_start);
+    if (rc) {
+        fprintf(stderr, "failed to get time");
+        return 1;
+    }
+
+    for (unsigned int i = 0; i < ROUNDS; ++i) {
+        for (unsigned int j = 0; j < N_TIMEZONES; ++j) {
+            escape(find_timezone(timezone_array[j].name));
+        }
+    }
+
+    rc = clock_gettime(CLOCK_MONOTONIC, &bm_end);
+    if (rc) {
+        fprintf(stderr, "failed to get time");
+        return 1;
+    }
+
+    fprintf(stdout, "avg find_timezone duration in ns: %lu",
+            timespec_diff_ns(&bm_start, &bm_end) / (ROUNDS * N_TIMEZONES));
+
+    return 0;
+}

--- a/generator/Program.cs
+++ b/generator/Program.cs
@@ -162,7 +162,7 @@ namespace brutezone
                     }
                     i++;
                 }
-                file.WriteLine(string.Join(",\r\n", singleStrings.ToArray()));
+                file.WriteLine(string.Join(",\n", singleStrings.ToArray()));
                 file.WriteLine("};");
                 file.WriteLine("");
 
@@ -184,7 +184,7 @@ namespace brutezone
                     {
                         strList.Add($"\t{{{(entry.StartTime - Epoch).Ticks / TimeSpan.TicksPerSecond},{(entry.EndTime - Epoch).Ticks / TimeSpan.TicksPerSecond},{entry.Offset / 60}}}");
                     }
-                    file.WriteLine(string.Join(",\r\n", strList.ToArray()));
+                    file.WriteLine(string.Join(",\n", strList.ToArray()));
                     file.WriteLine("};");
                     file.WriteLine("");
 
@@ -199,7 +199,7 @@ namespace brutezone
                 {
                     tzlist.Add($"\t{{\"{result.Key}\", {result.Value}}}");
                 }
-                file.WriteLine(string.Join(",\r\n", tzlist.ToArray()));
+                file.WriteLine(string.Join(",\n", tzlist.ToArray()));
                 file.WriteLine("};");
                 file.WriteLine("");
 

--- a/inc/timezone_database.h
+++ b/inc/timezone_database.h
@@ -23213,8 +23213,8 @@ static const tzdb_timezone timezone_array[TIMEZONE_DATABASE_COUNT] =
 	{"America/Pangnirtung", timezone_database_america_pangnirtung},
 	{"America/Paramaribo", timezone_database_america_paramaribo},
 	{"America/Phoenix", &timezone_database_no_change[4]},
-	{"America/Port_of_Spain", &timezone_database_no_change[7]},
 	{"America/Port-au-Prince", timezone_database_america_port_au_prince},
+	{"America/Port_of_Spain", &timezone_database_no_change[7]},
 	{"America/Porto_Velho", timezone_database_america_porto_velho},
 	{"America/Puerto_Rico", &timezone_database_no_change[7]},
 	{"America/Punta_Arenas", timezone_database_america_punta_arenas},
@@ -23480,14 +23480,25 @@ extern "C" {
 #endif
 static inline const tzdb_timezone* find_timezone(const char *timezone_name)
 {
-    unsigned int index;
+    const tzdb_timezone *begin = timezone_array;
+    const tzdb_timezone *end = timezone_array + TIMEZONE_DATABASE_COUNT;
 
-    // Iterate through all timezones
-    for(index = 0; index < TIMEZONE_DATABASE_COUNT; index++)
-    {
-        // Return the timezone if found
-        if(strcmp(timezone_array[index].name, timezone_name) == 0) return &timezone_array[index];
-    }
+    // Since the list of timezones above is always generated in sorted order,
+    // we use a binary search to find the timezone
+    do {
+        const tzdb_timezone *needle = begin + (end - begin) / 2;
+        const int cmp = strcmp(timezone_name, needle->name);
+        if (cmp > 0) {
+            begin = needle + 1;
+        }
+        else if (cmp < 0) {
+            end = needle;
+        }
+        else {
+            // Return the timezone if found
+            return needle;
+        }
+    } while (begin < end);
 
     // If the timezone was not found, return null
     return NULL;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required (VERSION 2.6)
 
 include_directories(../inc)
 
-set(CMAKE_CONFIGURATION_TYPES "Debug")
-
 file(GLOB tests
     "*.c"
 )

--- a/test/find_timezone.c
+++ b/test/find_timezone.c
@@ -1,20 +1,26 @@
 #include "timezone.h"
 #include <string.h>
 #include "test.h"
+#include "timezone_database.h"
 
 int main(void)
 {
-	const char timezonename[] = "America/Los_Angeles";
-	const tzdb_timezone *tz;
+	for (size_t i = 0; i < sizeof(timezone_array) / sizeof(*timezone_array); ++i) {
+		// Find the timezone
+		const tzdb_timezone *tz = find_timezone(timezone_array[i].name);
 
-	// Find the timezone
-	tz = find_timezone(timezonename);
+		if (!tz) {
+			printf("%s not found\n", timezone_array[i].name);
+		}
+		// Ensure the timezone was found
+		TEST_NOT_NULL(tz);
 
-	// Ensure the timezone was found
-	TEST_NOT_NULL(tz);
-
-	// Compare the timezone names
-	TEST_STRING_EQUAL(tz->name, timezonename);
+		// Compare the timezone names
+		if (strcmp(tz->name, timezone_array[i].name) != 0) {
+			printf("%s expected, %s found\n", timezone_array[i].name, tz->name);
+		}
+		TEST_STRING_EQUAL(tz->name, timezone_array[i].name);
+	}
 
 	// Attempt to find a non-valid timezone
 	TEST_NULL(find_timezone("Not/Valid"));


### PR DESCRIPTION
Since the list of timezones generated by the generator is always sorted by timezone name
we can take advantage of this and use a binary search when looking up by name.
Results in an approx. 10x speedup on average.

i based this pr on the fix timezone_gmt_time branch, mostly out of convenience. should be fine to merge after the bugfix is merged