### PR TITLE
rename TIMEZONE_AMBIGUATIVE_TIME to TIMEZONE_AMBIGUOUS_TIME

### DIFF
--- a/inc/timezone.h
+++ b/inc/timezone.h
@@ -11,7 +11,7 @@ extern "C" {
 enum timezone_err {
 	TIMEZONE_NOT_FOUND = -1,
 	TIMEZONE_OUT_OF_RANGE = -2,
-	TIMEZONE_AMBIGUATIVE_TIME = -3,
+	TIMEZONE_AMBIGUOUS_TIME = -3,
 	TIMEZONE_INVALID_TIME = -4,
 };
 
@@ -29,7 +29,7 @@ enum timezone_gmt_time_behaviour {
  * \param[in] localtime
  *
  * \return 1 if the given timestamp is DST, 0 if it isn't,
- *         TIMEZONE_AMBIGUATIVE_TIME if it is not defined due to daylight-time -> standard-time transition
+ *         TIMEZONE_AMBIGUOUS_TIME if it is not defined due to daylight-time -> standard-time transition
  *         TIMEZONE_INVALID_TIME if the timestamp is not a valid time due to standard-time -> daylight-time transition
  *         TIMEZONE_NOT_FOUND if the timezone was not found in the database
  *         TIMEZONE_OUT_OF_RANGE if the given timestamp is outside of the database range.
@@ -82,7 +82,7 @@ time_t timezone_current_local_time(const char *timezone);
  *             - returns the earlier one if behaviour is TIMEZONE_FIRST,
  *             - returns the later one if behaviour is TIMEZONE_LATTER,
  *             - returns either one if behaviour is TIMEZONE_ANY (fastest),
- *             - returns TIMEZONE_AMBIGUATIVE_TIME if behaviour is
+ *             - returns TIMEZONE_AMBIGUOUS_TIME if behaviour is
  *               TIMEZONE_STRICT
  *         - if local_time is an invalid time:
  *             - returns gmt time as if the earlier offset was still valid if

--- a/src/timezone.c
+++ b/src/timezone.c
@@ -86,11 +86,11 @@ int timezone_localtime_isdst(const char *timezone_name, time_t local_time)
 
 	const timezone_offset *next = offset + 1;
 	if (next < end && local_time - next->offset * 60 >= next->start)
-		return TIMEZONE_AMBIGUATIVE_TIME;
+		return TIMEZONE_AMBIGUOUS_TIME;
 
 	const timezone_offset *prev = offset - 1;
 	if (prev >= tz->entries && local_time - next->offset * 60 < offset->start)
-		return TIMEZONE_AMBIGUATIVE_TIME;
+		return TIMEZONE_AMBIGUOUS_TIME;
 
 	if ((prev >= tz->entries && prev->offset < offset->offset) ||
 	    (next < end && next->offset < offset->offset))
@@ -150,7 +150,7 @@ time_t timezone_gmt_time_explicit(const char *timezone_name, time_t local_time,
 		if ((offset > tz->entries && local_time - offset[-1].offset * 60 < offset->start) ||
 		    (offset < tz->entries + tz->n_entries - 1 && local_time - offset[1].offset * 60 >= offset[1].start))
 		{
-			return TIMEZONE_AMBIGUATIVE_TIME;
+			return TIMEZONE_AMBIGUOUS_TIME;
 		}
 		return local_time - offset->offset * 60;
 	}

--- a/test/timezone_gmt_time.c
+++ b/test/timezone_gmt_time.c
@@ -27,14 +27,14 @@ static void test_gmtime(const char *timezonename)
 		TEST_NOT_EQUAL(isdst, TIMEZONE_INVALID_TIME);
 
 		// Revert back to gmt
-		if (isdst == TIMEZONE_AMBIGUATIVE_TIME) {
+		if (isdst == TIMEZONE_AMBIGUOUS_TIME) {
 			// could be either of these
 			const time_t revert_a = timezone_gmt_time_explicit(timezonename, localtime, TIMEZONE_FIRST);
 			const time_t revert_b = timezone_gmt_time_explicit(timezonename, localtime, TIMEZONE_LATTER);
 			TEST_TRUE(gmtime == revert_a || gmtime == revert_b);
 			TEST_TRUE(revert_b > revert_a);
 			TEST_EQUAL(timezone_gmt_time_explicit(timezonename, localtime, TIMEZONE_STRICT),
-			           TIMEZONE_AMBIGUATIVE_TIME);
+			           TIMEZONE_AMBIGUOUS_TIME);
 		}
 		else {
 			const time_t revert = timezone_gmt_time(timezonename, localtime);

--- a/test/timezone_localtime_isdst.c
+++ b/test/timezone_localtime_isdst.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
 	// thus 2020-10-25 02:00:00 to 2020-10-25 02:59:59 could be either daylight saving time or not
 	const time_t local_2020_10_25_02_00_00 = 1603591200;
 	for (time_t i = 0; i < SEC_PER_HOUR; ++i) {
-		TEST_EQUAL(TIMEZONE_AMBIGUATIVE_TIME, timezone_localtime_isdst(timezone, local_2020_10_25_02_00_00 + i));
+		TEST_EQUAL(TIMEZONE_AMBIGUOUS_TIME, timezone_localtime_isdst(timezone, local_2020_10_25_02_00_00 + i));
 	}
 
 	// and 2020-10-25 01:59:59 is daylight saving time


### PR DESCRIPTION
Since writting this I've come to the conclusion that ambiguative is apparently not a word, at least in the english language. :grinning: