### PR TITLE
improve performance of the generator

### DIFF
--- a/inc/timezone_database.h
+++ b/inc/timezone_database.h
@@ -454,7 +454,7 @@ static const timezone_offset timezone_database_africa_khartoum[] =
 static const timezone_offset timezone_database_africa_monrovia[] =
 {
 	{0,-44},
-	{63593100,0}
+	{63593070,0}
 };
 
 static const timezone_offset timezone_database_africa_ndjamena[] =


### PR DESCRIPTION
Somewhat inspired by issue #16 I looked into improving the performance of the generator. 

Turns out it's quite easy to query NodaTime for the end of the timezone-interval, instead of using bruteforce.
.
This changes one single entry in the timezone_database.h, for Africa/Monrovia,
but this is because the previous entry was incorrect since it isn't at a clean minute
border and thus the correct timestamp for the interval was skipped. ([source](https://timezonedb.com/time-zones/Africa/Monrovia))